### PR TITLE
Small fixes, formatting, and two additional papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ Papers and Codes for the deep learning in hyperbolic space
 |:------------|:--------------:|:----------------------:|:-----------------------:|:----------------------:|
 | [Hyperbolic Deep Neural Networks: A Survey](https://arxiv.org/pdf/2101.04562.pdf) | TPAMI2022 | Survey | -  | - |
 | [Hyperbolic Image Segmentation](https://arxiv.org/pdf/2203.05898.pdf) | CVPR2022 | Latent | Segmentation  | [PyTorch](https://github.com/MinaGhadimiAtigh/HyperbolicImageSegmentation) |
+| [Hyperbolic Vision Transformers: Combining Improvements in Metric Learning](https://arxiv.org/pdf/2203.10833.pdf) | CVPR2022 | Embedding | CV | [PyTorch](https://github.com/htdt/hyp_metric) |
+| [Clipped Hyperbolic Classifiers Are Super-Hyperbolic Classifiers](https://arxiv.org/pdf/2107.11472.pdf) | CVPR2022 | - | Classification | -
 |   ------------------------------------------ | ------------ | --------- | -----------  | --------- | 
 | [Curvature Generation in Curved Spaces for Few-Shot Learning](https://openaccess.thecvf.com/content/ICCV2021/papers/Gao_Curvature_Generation_in_Curved_Spaces_for_Few-Shot_Learning_ICCV_2021_paper.pdf) | ICCV2021 | Latent | Few-shot  | [PyTorch](https://github.com/ZhiGaomcislab/CurvatureGeneration_FSL) |
 | [Unsupervised Discovery of the Long-Tail in Instance Segmentation Using Hierarchical Self-Supervision](https://arxiv.org/pdf/2104.01257.pdf) | CVPR2021 | Latent | Segmentation  | [PyTorch](https://github.com/ZZWENG/longtail_segmentation) |
 | [Symmetric Spaces for Graph Embeddings](https://proceedings.mlr.press/v139/lopez21a.html) | ICML2021 | Metric | Graph  | [PyTorch](https://github.com/fedelopez77/sympa) |
 | [Hyperbolic Busemann Learning with Ideal Prototypes ](https://arxiv.org/pdf/2106.14472.pdf) | NeurIPS2021 | Loss | Graph  | [PyTorch](https://github.com/minaghadimiatigh/hyperbolic-busemann-learning) |
 | [Learning Hyperbolic Representations of Topological Features](https://openreview.net/forum?id=yqPnIRhHtZv) | ICLR2021 | MLP | Graphs  | [Tensorflow ](https://github.com/pkyriakis/permanifold) |
-| [Fully Hyperbolic Neural Networks](https://arxiv.org/pdf/2105.14686.pdf) | 2021 | GNN | Graphs  | [PyTorch](https://github.com/chenweize1998/fully-hyperbolic-nn) |
+| [Fully Hyperbolic Neural Networks](https://arxiv.org/pdf/2105.14686.pdf) | ACL2022 | GNN | Graphs  | [PyTorch](https://github.com/chenweize1998/fully-hyperbolic-nn) |
 | [Unsupervised Hyperbolic Representation Learning via Message Passing Auto-Encoders](https://arxiv.org/abs/2103.16046) | CVPR2021 | AutoEncoder | Graph  | [PyTorch](https://github.com/junhocho/HGCAE)|
 | [Learning the Predictability of the Future](https://arxiv.org/pdf/2101.01600.pdf) | CVPR2021 | only Latent | CV  | [PyTorch](https://github.com/cvlab-columbia/hyperfuture)|
 | [Hyperbolic Neural Networks++](https://openreview.net/forum?id=Ec85b0tUwbA) | ICLR2021 | NN | NLP  | [PyTorch](https://github.com/mil-tokyo/hyperbolic_nn_plusplus)|

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Papers and Codes for the deep learning in hyperbolic space
 |:------------|:--------------:|:----------------------:|:-----------------------:|:----------------------:|
 | [Hyperbolic Deep Neural Networks: A Survey](https://arxiv.org/pdf/2101.04562.pdf) | TPAMI2022 | Survey | -  | - |
 | [Hyperbolic Image Segmentation](https://arxiv.org/pdf/2203.05898.pdf) | CVPR2022 | Latent | Segmentation  | [PyTorch](https://github.com/MinaGhadimiAtigh/HyperbolicImageSegmentation) |
-| [Curvature Generation in Curved Spaces for Few-Shot Learning](https://openaccess.thecvf.com/content/ICCV2021/papers/Gao_Curvature_Generation_in_Curved_Spaces_for_Few-Shot_Learning_ICCV_2021_paper.pdf) | ICCV2021 | latent | Few-shot  | [PyTorch](https://github.com/ZhiGaomcislab/CurvatureGeneration_FSL) |
-| [Unsupervised Discovery of the Long-Tail in Instance Segmentation Using Hierarchical Self-Supervision](https://arxiv.org/pdf/2104.01257.pdf) | CVPR2021 | latent | segmentation  | [PyTorch](https://github.com/ZZWENG/longtail_segmentation) |
+|   ------------------------------------------ | ------------ | --------- | -----------  | --------- | 
+| [Curvature Generation in Curved Spaces for Few-Shot Learning](https://openaccess.thecvf.com/content/ICCV2021/papers/Gao_Curvature_Generation_in_Curved_Spaces_for_Few-Shot_Learning_ICCV_2021_paper.pdf) | ICCV2021 | Latent | Few-shot  | [PyTorch](https://github.com/ZhiGaomcislab/CurvatureGeneration_FSL) |
+| [Unsupervised Discovery of the Long-Tail in Instance Segmentation Using Hierarchical Self-Supervision](https://arxiv.org/pdf/2104.01257.pdf) | CVPR2021 | Latent | Segmentation  | [PyTorch](https://github.com/ZZWENG/longtail_segmentation) |
 | [Symmetric Spaces for Graph Embeddings](https://proceedings.mlr.press/v139/lopez21a.html) | ICML2021 | Metric | Graph  | [PyTorch](https://github.com/fedelopez77/sympa) |
 | [Hyperbolic Busemann Learning with Ideal Prototypes ](https://arxiv.org/pdf/2106.14472.pdf) | NeurIPS2021 | Loss | Graph  | [PyTorch](https://github.com/minaghadimiatigh/hyperbolic-busemann-learning) |
 | [Learning Hyperbolic Representations of Topological Features](https://openreview.net/forum?id=yqPnIRhHtZv) | ICLR2021 | MLP | Graphs  | [Tensorflow ](https://github.com/pkyriakis/permanifold) |
@@ -21,17 +22,17 @@ Papers and Codes for the deep learning in hyperbolic space
 | [HGCF: Hyperbolic GCN for Collaborative Filtering](cs.toronto.edu/~mvolkovs/www2021_hgcf.pdf) | WWW2021 | Clustering | Recommendation  | [PyTorch](https://github.com/ruocwang/darts-pt)|
 | [Highly Scalable and Provably Accurate Classification in Poincare Balls](https://arxiv.org/pdf/2109.03781.pdf) | ICDM2021 | Embedding | Cell  | [Python](https://github.com/thupchnsky/PoincareLinearClassification)|
 |   ---------------------------------------- | ------------ | --------- | -----------  | --------- | 
-| [Hyperbolic Distance Matrices](https://dl.acm.org/doi/abs/10.1145/3394486.3403224) | KDD2020 | Lorentzian | NLP/Tree  | [python](https://github.com/puoya/hyperbolic-distance-matrices)|
-| [Poincaré maps for analyzing complex hierarchies in single-cell data](https://www.nature.com/articles/s41467-020-16822-4) | Nature | Embedding | Cells  | [pyTorch](https://github.com/facebookresearch/PoincareMaps)|
+| [Hyperbolic Distance Matrices](https://dl.acm.org/doi/abs/10.1145/3394486.3403224) | KDD2020 | Lorentzian | NLP/Tree  | [Python](https://github.com/puoya/hyperbolic-distance-matrices)|
+| [Poincaré maps for analyzing complex hierarchies in single-cell data](https://www.nature.com/articles/s41467-020-16822-4) | Nature | Embedding | Cells  | [PyTorch](https://github.com/facebookresearch/PoincareMaps)|
 | [ Differentiating through the Frechet Mean](https://arxiv.org/pdf/2003.00335.pdf) | ICML 2020 | GNN | Graph  | [PyTorch](https://github.com/CUAI/Differentiable-Frechet-Mean) | 
 | [Constant Curvature Graph Convolutional Networks](https://openreview.net/forum?id=Ec85b0tUwbA) | ICML 2020 | GCN | Graph  | - |
-| [Mix Dimension in Poincar\'{e} Geometry for 3D Skeleton-based Action Recognition](https://dl.acm.org/doi/pdf/10.1145/3394171.3413910) | MM2020 | GCN | Grpah  | - |
+| [Mix Dimension in Poincaré Geometry for 3D Skeleton-based Action Recognition](https://dl.acm.org/doi/pdf/10.1145/3394171.3413910) | MM2020 | GCN | Graph  | - |
 | [Searching for Actions on the Hyperbole](https://openaccess.thecvf.com/content_CVPR_2020/papers/Long_Searching_for_Actions_on_the_Hyperbole_CVPR_2020_paper.pdf) | CVPR2020 | Latent | CV  | [PyTorch](https://github.com/Tenglon/hyperbolic_action)|
 | [Hyperbolic Image Embedding](https://github.com/leymir/hyperbolic-image-embeddings) | CVPR2020 | only Latent | CV  | [PyTorch](https://github.com/leymir/hyperbolic-image-embeddings)|
 | [Hyperbolic Zero shot Learning](https://github.com/ShaoTengLiu/Hyperbolic_ZSL) | CVPR2020 | NN | CV  | [PyTorch](https://github.com/ShaoTengLiu/Hyperbolic_ZSL)|
 | [Hyperbolic Hierarchical Clustering](https://arxiv.org/abs/2010.00402) | NeurIPS2020 | Clustering | Classification  | [PyTorch](https://github.com/ruocwang/darts-pt)|
 |   ------------------------------------------| ------------ | --------- | -----------  | --------- | 
-| [Hyperbolic graph convolutional neural networks](https://arxiv.org/abs/1910.12933) | NeurIPS2019 | GCN | Grpah  | [PyTorch](https://github.com/HazyResearch/hgcn)|
+| [Hyperbolic graph convolutional neural networks](https://arxiv.org/abs/1910.12933) | NeurIPS2019 | GCN | Graph  | [PyTorch](https://github.com/HazyResearch/hgcn)|
 | [Hyperbolic Ordinal Embedding](https://dl.acm.org/doi/abs/10.1145/3394486.3403224) | ACML2019 | Ordinal Embedding | NLP/Tree  | - |
 | [Hyperbolic Graph Neural Networks](https://papers.nips.cc/paper/2019/hash/103303dd56a731e377d01f6a37badae3-Abstract.html) | NeurIPS2019 | GNN | Molecular Structures | [PyTorch](https://github.com/facebookresearch/hgnn)|
 |   ----------------------------------------- | ------------ | --------- | -----------  | --------- | 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Papers and Codes for the deep learning in hyperbolic space
 | [Learning the Predictability of the Future](https://arxiv.org/pdf/2101.01600.pdf) | CVPR2021 | only Latent | CV  | [PyTorch](https://github.com/cvlab-columbia/hyperfuture)|
 | [Hyperbolic Neural Networks++](https://openreview.net/forum?id=Ec85b0tUwbA) | ICLR2021 | NN | NLP  | [PyTorch](https://github.com/mil-tokyo/hyperbolic_nn_plusplus)|
 | [A Hyperbolic-to-Hyperbolic Graph Convolutional Network](https://arxiv.org/pdf/2104.06942.pdf) | CVPR2021 | GNN | Graph  | [PyTorch](https://github.com/JindouDai/H2H-GCN) | 
-| [HoroPCA: Hyperbolic Dimensionality Reduction via Horospherical Projections] | ICML2021 | NN | Visualization  | -| 
+| [HoroPCA: Hyperbolic Dimensionality Reduction via Horospherical Projections](http://proceedings.mlr.press/v139/chami21a/chami21a.pdf) | ICML2021 | NN | Visualization  | [PyTorch](https://github.com/HazyResearch/HoroPCA) | 
 | [Generalization Error Bound for Hyperbolic Ordinal Embedding](https://openreview.net/forum?id=Ec85b0tUwbA) | ICML2021 | NN | NLP  | - |
 | [HGCF: Hyperbolic GCN for Collaborative Filtering](cs.toronto.edu/~mvolkovs/www2021_hgcf.pdf) | WWW2021 | Clustering | Recommendation  | [PyTorch](https://github.com/ruocwang/darts-pt)|
 | [Highly Scalable and Provably Accurate Classification in Poincare Balls](https://arxiv.org/pdf/2109.03781.pdf) | ICDM2021 | Embedding | Cell  | [Python](https://github.com/thupchnsky/PoincareLinearClassification)|


### PR DESCRIPTION
## Overview of changes
- Added a dash row separating 2022, like all the other years
- Fixed a small spelling mistake
- Some other formatting which may look nicer, like uniform capitalization
- Added missing links for a paper (HoroPCA)
- Added two papers from CVPR 2022 (Hyperbolic-ViT & Clipped Hyperbolic Classifiers)

## Some remarks on the two papers I added in 2022
### Hyperbolic Vision Transformers
After reading the CVPR 2020 paper, I was wondering why hasn't anyone simply extended this to ViTs, i.e. by projecting the isometric N-dimensional embeddings to an N-dimensional poincaré ball. So after a quick search online, I found this paper doing that.

(I still feel like this is not a fully hyperbolic ViT though. Instead of converting to hyperbolic embeddings at the end, the patch-embedding layer at the start of the model should map patches to the poincaré ball, and then some equivalent operation to self-attention should be done.)

### Clipped Hyperbolic Classifiers
This is pretty useful to the general field of hyperbolic vision I believe. They say that in the type of problems when we have `nn layers in euclidean space` -> followed by -> `classifier head in hyperbolic space`, there is apparently a problem of vanishing gradients caused by the transition between geometric spaces. And the simple yet effective solution to this is weight clipping in the euclidean layers. Couldn't find code for this, but the hypothesis should be easy enough to implement / verify.

